### PR TITLE
feat: add initialization methods for SmartAccount

### DIFF
--- a/Sources/CustomAuthSdk/SmartAccount.swift
+++ b/Sources/CustomAuthSdk/SmartAccount.swift
@@ -34,6 +34,18 @@ public class SmartAccount {
         builder = nil
     }
 
+    public func initialize(options: SmartAccountInitByKeyOptions) async throws {
+        builder = try builder!.withMasterKey(key: options.key)
+        inner = try await builder?.build()
+        builder = nil
+    }
+    
+    public func initialize(options: SmartAccountInitByKeysetJsonOptions) async throws {
+        builder = try builder!.withKeysetJson(keysetJson: options.keysetJson)
+        inner = try await builder?.build()
+        builder = nil
+    }
+    
     public func address() async throws -> String {
         try requireInit()
         return Data(inner!.address()).web3.hexString

--- a/Sources/CustomAuthSdk/SmartAccount.swift
+++ b/Sources/CustomAuthSdk/SmartAccount.swift
@@ -35,13 +35,13 @@ public class SmartAccount {
     }
 
     public func initialize(options: SmartAccountInitByKeyOptions) async throws {
-        builder = try builder!.withMasterKey(key: options.key)
+        builder = try builder!.withActiveChain(activeChain: options.chainId.rawValue).withMasterKey(key: options.key)
         inner = try await builder?.build()
         builder = nil
     }
     
     public func initialize(options: SmartAccountInitByKeysetJsonOptions) async throws {
-        builder = try builder!.withKeysetJson(keysetJson: options.keysetJson)
+        builder = try builder!.withActiveChain(activeChain: options.chainId.rawValue).withKeysetJson(keysetJson: options.keysetJson)
         inner = try await builder?.build()
         builder = nil
     }

--- a/Sources/CustomAuthSdk/SmartAccountTypes.swift
+++ b/Sources/CustomAuthSdk/SmartAccountTypes.swift
@@ -79,15 +79,19 @@ public struct SmartAccountInitOptions{
 }
 
 public struct SmartAccountInitByKeyOptions {
+    public var chainId: ChainID
     public var key: Key
-    public init(key: Key) {
+    public init(chainId: ChainID, key: Key) {
+        self.chainId = chainId
         self.key = key
     }
 }
 
 public struct SmartAccountInitByKeysetJsonOptions {
+    public var chainId: ChainID
     public var keysetJson: String
-    public init(keysetJson: String) {
+    public init(chainId: ChainID, keysetJson: String) {
+        self.chainId = chainId
         self.keysetJson = keysetJson
     }
 }

--- a/Sources/CustomAuthSdk/SmartAccountTypes.swift
+++ b/Sources/CustomAuthSdk/SmartAccountTypes.swift
@@ -78,6 +78,20 @@ public struct SmartAccountInitOptions{
     }
 }
 
+public struct SmartAccountInitByKeyOptions {
+    public var key: Key
+    public init(key: Key) {
+        self.key = key
+    }
+}
+
+public struct SmartAccountInitByKeysetJsonOptions {
+    public var keysetJson: String
+    public init(keysetJson: String) {
+        self.keysetJson = keysetJson
+    }
+}
+
 internal class WrapSigner: Shared.Signer {
     private var signer: Signer
     


### PR DESCRIPTION
Implement the equivalent [methods on Android](https://github.com/UniPassID/custom-auth-android-sdk/blob/ffacb3701c8a599125b1ede9c3815966f136696e/smartAccount/src/main/java/com/unipass/smartAccount/smartAccount.kt#L55)

```kotlin
    public final suspend fun init(options: com.unipass.smartAccount.SmartAccountInitByKeysOptions): kotlin.Unit { /* compiled code */ }

    public final suspend fun init(options: com.unipass.smartAccount.SmartAccountInitByKeysetJsonOptions): kotlin.Unit { /* compiled code */ }
```